### PR TITLE
fix download error when no annotation_summary in genome nexus annotation

### DIFF
--- a/src/shared/cache/GenomeNexusMutationAssessorCache.ts
+++ b/src/shared/cache/GenomeNexusMutationAssessorCache.ts
@@ -44,8 +44,7 @@ export default class GenomeNexusMutationAssessorCache extends LazyMobXCache<
     constructor(customFetch?: any) {
         super(
             (m: Mutation) => queryToKey(m), // queryToKey
-            (v: VariantAnnotation) =>
-                genomicLocationString(v.annotation_summary.genomicLocation), // dataToKey
+            (v: VariantAnnotation) => v.originalVariantQuery, // dataToKey
             customFetch || defaultGNFetch
         );
     }


### PR DESCRIPTION
This variant annotation is failing so we couldn't map it back by genomic location:
```
{
    "variant": "6:g.152419921_152419920delinsTCTC",
    "originalVariantQuery": "6,152419920,152419920,TCTAT,TTCTC",
    "successfully_annotated": false
  }
```
Mapping by `originalVariantQuery` instead